### PR TITLE
Updating to use OpenAPI Deiff version 2.1.0-beta.8

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.9-tem

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ https://github.com/OpenAPITools/openapi-diff[OpenAPITools Diff Tool] is useful i
 
 
 
-The plugin has been implemented with an Extension, allowing for teh configuration options to be passed in a block assigned with "openapi_diff", and can be used in the build.gradle file
+The plugin has been implemented with an Extension, allowing for the configuration options to be passed in a block assigned with "openapi_diff", and can be used in the build.gradle file
 
 [source,groovy]
 ----
@@ -51,7 +51,7 @@ task triggerCompatible(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPluginTas
 |failOnChange |Property<Boolean> |false |No |Set to true if you wish for the build to fail on any changes.
 
 
-|failOnIncompatible |Property<Boolean> |false |No |Set to ture if you wish for the build to fail on incompatible changes.
+|failOnIncompatible |Property<Boolean> |false |No |Set to true if you wish for the build to fail on incompatible changes.
 
 |htmlReport |Property<Boolean> |false |No |Enable to create a comparison report in HTML format.
 
@@ -60,6 +60,8 @@ task triggerCompatible(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPluginTas
 |textReport |Property<Boolean> |false |No |Enable to create a comparison report Plaintext format.
 
 |markdownReport |Property<Boolean> |false |No |Enable to create a comparison report Markdown format.
+
+|asciidocReport |Property<Boolean> |false |No |Enable to create a comparison report Asciidoc format.
 
 |reportName |Property<String> | "build/Openapi_Diff_Report" |No |The location and name to use for any report file.
 |===
@@ -74,6 +76,7 @@ If this is left as default then the reports will be named
 |"build/Openapi_Diff_Report.json"
 |"build/Openapi_Diff_Report.md"
 |"build/Openapi_Diff_Report.html"
+|"build/Openapi_Diff_Report.adoc"
 |===
 
 depending on which options are enabled.
@@ -101,7 +104,7 @@ If the version is set with "-SNAPSHOT" it will automatically publish locally to 
 
 To perform testing local you can run the Gradle build in the demo sub-directory. This will use the ./repo directory to source the plugin for testing.
 
-Another way to test the plugin is to run the following from teh root directory.
+Another way to test the plugin is to run the following from the root directory.
 
 [source,bash]
 ----
@@ -114,7 +117,7 @@ This will run JUnit tests and will trigger TestKit tests with the functionalTest
 
 To publish the plugin you need to
 
-. Ensure the API key and secrent, for x3tadmin, have been added to ~/.gradle/gradle.properties
+. Ensure the API key and secret, for x3tadmin, have been added to ~/.gradle/gradle.properties
 . The version string has been updated to remove "-SNAPSHOT" and is greater than the last published version.
 
 You then need to open a terminal and run

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation gradleTestKit()
 
-    implementation 'org.openapitools.openapidiff:openapi-diff-core:2.1.0-beta.7'
+    implementation 'org.openapitools.openapidiff:openapi-diff-core:2.1.0-beta.8'
     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
 
     testImplementation gradleTestKit()

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -45,6 +45,12 @@ task createMarkdownReport(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPlugin
     markdownReport.set(true)
 }
 
+task createAsciidocReport(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPluginTask){
+    originalFile = "${projectDir}/missing_property_1.yaml"
+    newFile = "${projectDir}/missing_property_2.yaml"
+    asciidocReport.set(true)
+}
+
 task createDifferentReport(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPluginTask){
     originalFile = "${projectDir}/missing_property_1.yaml"
     newFile = "${projectDir}/missing_property_2.yaml"
@@ -53,4 +59,4 @@ task createDifferentReport(type: com.x3t.gradle.plugins.openapi.OpenapiDiffPlugi
 }
 
 task testTasks(dependsOn: ['triggerCompatible', 'triggerFailOnChange'])
-task testReports(dependsOn: ['createTextReport', 'createHtmlReport', 'createJsonReport', 'createMarkdownReport', 'createDifferentReport'])
+task testReports(dependsOn: ['createTextReport', 'createHtmlReport', 'createJsonReport', 'createMarkdownReport', 'createDifferentReport', 'createAsciidocReport'])

--- a/src/functionalTest/kotlin/com/x3t/gradle/plugins/openapi/TestPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/com/x3t/gradle/plugins/openapi/TestPluginFunctionalTest.kt
@@ -255,6 +255,41 @@ class TestPluginFunctionalTest {
         assertTrue(data.contains("* Deleted property `childProperty` (object)"))
     }
 
+    @Test fun canCreateAsciidocReport() {
+        // Set up the test build
+        settingsFile.writeText("")
+        buildFile.writeText("""
+            plugins {
+                id('com.x3t.gradle.plugins.openapi.openapi_diff')
+            }
+            
+            openapi_diff {
+                originalFile = "${projectDir}/missing_1.yaml"
+                newFile = "${projectDir}/missing_2.yaml"
+                asciidocReport.set(true)
+            }
+        """.trimIndent())
+
+        Files.copy(missingFile1,testFile1.toPath())
+        Files.copy(missingFile2,testFile2.toPath())
+
+        // Run the build
+        val runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("openapi_diff")
+        runner.withProjectDir(projectDir)
+        val result = runner.build()
+
+        // Verify the result
+        assertTrue(result.toString().isNotEmpty())
+        val reportPath = projectDir.resolve("build/Openapi_Diff_Report.adoc")
+        val data = reportPath.readText()
+
+        assertTrue(Files.exists(reportPath.toPath()))
+        assertTrue(data.contains("NOTE: API changes are backward compatible"))
+    }
+
     @Test fun canChangeReportName() {
         // Set up the test build
         settingsFile.writeText("")

--- a/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPlugin.kt
+++ b/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPlugin.kt
@@ -15,6 +15,7 @@ class OpenapiDiffPlugin : Plugin<Project> {
             it.jsonReport.set(diffExtention.jsonReport)
             it.textReport.set(diffExtention.textReport)
             it.markdownReport.set(diffExtention.markdownReport)
+            it.asciidocReport.set(diffExtention.asciidocReport)
             it.reportName.set(diffExtention.reportName)
             it.originalFile.set(diffExtention.originalFile)
             it.newFile.set(diffExtention.newFile)

--- a/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginExtention.kt
+++ b/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginExtention.kt
@@ -14,6 +14,7 @@ open class OpenapiDiffPluginExtention(project: Project) {
     val jsonReport : Property<Boolean>  = objects.property(Boolean::class.java).convention(false)
     val textReport : Property<Boolean>  = objects.property(Boolean::class.java).convention(false)
     val markdownReport : Property<Boolean>  = objects.property(Boolean::class.java).convention(false)
+    val asciidocReport : Property<Boolean>  = objects.property(Boolean::class.java).convention(false)
 
     val originalFile : Property<String> = objects.property(String::class.java)
     val newFile : Property<String> = objects.property(String::class.java)
@@ -35,5 +36,6 @@ open class OpenapiDiffPluginExtention(project: Project) {
         jsonReport.set(false)
         textReport.set(false)
         markdownReport.set(false)
+        asciidocReport.set(false)
     }
 }

--- a/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginTask.kt
+++ b/src/main/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginTask.kt
@@ -15,6 +15,7 @@ import org.openapitools.openapidiff.core.output.ConsoleRender
 import org.openapitools.openapidiff.core.output.HtmlRender
 import org.openapitools.openapidiff.core.output.JsonRender
 import org.openapitools.openapidiff.core.output.MarkdownRender
+import org.openapitools.openapidiff.core.output.AsciidocRender
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStreamWriter
@@ -46,6 +47,10 @@ abstract class OpenapiDiffPluginTask @Inject constructor(private val objectFacto
     @get:Optional
     @get:Input
     abstract val markdownReport : Property<Boolean>
+
+    @get:Optional
+    @get:Input
+    abstract val asciidocReport : Property<Boolean>
 
     @get:Optional
     @get:Input
@@ -145,11 +150,20 @@ abstract class OpenapiDiffPluginTask @Inject constructor(private val objectFacto
 
         if( markdownReport.isPresent and markdownReport.get()) {
             val localOutputFile = "%s.md".format(outputFile)
-            logger.debug("PlaintextFile - Report Name: $localOutputFile")
+            logger.debug("MarkdownFile - Report Name: $localOutputFile")
             val mdRender = MarkdownRender()
             val outputStream = FileOutputStream(localOutputFile)
             val outputStreamWriter = OutputStreamWriter(outputStream)
             mdRender.render(result, outputStreamWriter)
+        }
+
+        if( asciidocReport.isPresent and asciidocReport.get()) {
+            val localOutputFile = "%s.adoc".format(outputFile)
+            logger.debug("AsciiDocFile - Report Name: $localOutputFile")
+            val asciidocRender = AsciidocRender()
+            val outputStream = FileOutputStream(localOutputFile)
+            val outputStreamWriter = OutputStreamWriter(outputStream)
+            asciidocRender.render(result, outputStreamWriter)
         }
 
         if(failOnChange.isPresent and failOnChange.get() and !result.isUnchanged){
@@ -166,9 +180,9 @@ abstract class OpenapiDiffPluginTask @Inject constructor(private val objectFacto
         jsonReport.set(false)
         textReport.set(false)
         markdownReport.set(false)
+        asciidocReport.set(false)
         failOnIncompatible.set(false)
         failOnChange.set(false)
         reportName.set(project.layout.buildDirectory.get().toString() + File.separator + "Openapi_Diff_Report")
-
     }
 }

--- a/src/test/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginTest.kt
+++ b/src/test/kotlin/com/x3t/gradle/plugins/openapi/OpenapiDiffPluginTest.kt
@@ -39,6 +39,7 @@ class OpenapiDiffPluginTest {
         assertNotEquals(true, task.jsonReport.get())
         assertNotEquals(true, task.textReport.get())
         assertNotEquals(true, task.markdownReport.get())
+        assertNotEquals(true, task.asciidocReport.get())
     }
 
     @Test
@@ -74,6 +75,23 @@ class OpenapiDiffPluginTest {
     }
 
     @Test
+    fun `Test Asciidoc Report Parameters passed correctly`() {
+        val project = ProjectBuilder.builder().build()
+        project.pluginManager.apply("com.x3t.gradle.plugins.openapi.openapi_diff")
+        (project.extensions.getByName("openapi_diff") as OpenapiDiffPluginExtention).apply {
+            asciidocReport.set(true)
+        }
+
+        val task = project.tasks.getByName("openapi_diff") as OpenapiDiffPluginTask
+
+        assertEquals(true, task.asciidocReport.get())
+        assertNotEquals(true, task.htmlReport.get())
+        assertNotEquals(true, task.textReport.get())
+        assertNotEquals(true, task.jsonReport.get())
+        assertNotEquals(true, task.markdownReport.get())
+    }
+
+    @Test
     fun `Test Text Report Parameters passed correctly`() {
         val project = ProjectBuilder.builder().build()
         project.pluginManager.apply("com.x3t.gradle.plugins.openapi.openapi_diff")
@@ -87,5 +105,6 @@ class OpenapiDiffPluginTest {
         assertNotEquals(true, task.htmlReport.get())
         assertNotEquals(true, task.markdownReport.get())
         assertNotEquals(true, task.jsonReport.get())
+        assertNotEquals(true, task.asciidocReport.get())
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,5 +1,5 @@
 ext {
     jvm_version = 1.17
     kotlin_version = '1.9.0'
-    plugin_version = '1.0-SNAPSHOT'
+    plugin_version = '1.0.1-SNAPSHOT'
 }


### PR DESCRIPTION
This version adds in our changes to allow Asciidoc reports to be generated.